### PR TITLE
Allow / as a valid character in CF file names

### DIFF
--- a/lib/rackit.js
+++ b/lib/rackit.js
@@ -659,9 +659,9 @@ Rackit.prototype.getURI = function (sCloudPath, ttl) {
  */
 Rackit.prototype._getCDNURI = function (sCloudPath) {
 	var o1 = this;
-	var aPieces = sCloudPath.split('/');
-	var sContainer = aPieces[0];
-	var localPath = aPieces[1];
+	var aPieces = sCloudPath.match(/^\/{0,1}([^/]+)\/(.+)$/);
+	var sContainer = aPieces[1];
+	var localPath = aPieces[2];
 
 	var CDNContainer = o1.hCDNContainers[sContainer];
 	if (!CDNContainer) {
@@ -767,9 +767,9 @@ Rackit.prototype._cloudpathFromCDNURI = function (uri) {
  * @return {string} The Cloudpath representing the file
  */
 Rackit.prototype._cloudpathFromTempURI = function (uri) {
-	var parts = url.parse(uri).pathname.split('/');
-	var file = parts.pop();
-	var container = parts.pop();
+	var parts = url.parse(uri).pathname.match(/^\/{0,1}([^/]+)\/(.+)$/);
+	var file = parts[2];
+	var container = parts[1];
 	return container + '/' + file;
 };
 


### PR DESCRIPTION
Replaced .split('/') with a RegExps to match correct parts of filenames.
