### PR TITLE
fix options.filename for id variable

### DIFF
--- a/lib/rackit.js
+++ b/lib/rackit.js
@@ -342,7 +342,7 @@ Rackit.prototype.add = function (source, options, cb) {
 			}
 
 			// Generate file id
-			var id = options.filename || utils.uid(24);
+			var id = o1.options.filename || utils.uid(24);
 
 			//
 			// Generate the headers to be send to Rackspace


### PR DESCRIPTION
Hey @rossj  - I noticed the filename option wasn't working, looks like it was just missing a reference to "this" - o1. Great library btw.
