### PR TITLE
Container Metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ When initializing Rackit, here are the options and defaults:
 	authRegion : 'US', // Specifies the authentication API entry point - other option of 'UK'
 	region : '', // Specifies the geographic datacenter to prefer - defaults to the user's default region. Explicit options of 'ORD', 'DFW', 'HKG', 'LON', 'IAD', 'SYD' are accepted.
 	tempURLKey : null, // A secret for generating temporary URLs
+	containerMetadata: { // Add default metadata to Cloud File containers (optional)
+		"key": "value"
+	},
 	useSNET : false,
 	useCDN : true,
 	useSSL : true, // Specifies whether to use SSL (https) for CDN links

--- a/lib/rackit.js
+++ b/lib/rackit.js
@@ -1,219 +1,274 @@
 /*global require, process, console*/
 // node modules
-var fs = require('fs');
-var url = require('url');
-var http = require('http');
-var crypto = require('crypto');
+var fs = require("fs");
+var url = require("url");
+var http = require("http");
+var crypto = require("crypto");
 
 // npm modules
-var _ = require('lodash');
-var mime = require('mime');
-var async = require('async');
-var pkgcloud = require('pkgcloud');
-var File = require('pkgcloud/lib/pkgcloud/rackspace/storage/file').File;
-var utils = require('./utils');
+var _ = require("lodash");
+var mime = require("mime");
+var async = require("async");
+var pkgcloud = require("pkgcloud");
+var File = require("pkgcloud/lib/pkgcloud/rackspace/storage/file").File;
+var utils = require("./utils");
 
-var Rackit = function (options) {
-	// Check the region
-	if (!options || !options.region) {
-		throw new Error('You must specify a region.');
-	}
+var Rackit = function(options) {
+  // Check the region
+  if (!options || !options.region) {
+    throw new Error("You must specify a region.");
+  }
 
-	this.options = Object.create(Rackit.defaultOptions);
+  this.options = Object.create(Rackit.defaultOptions);
 
-	// Override the default options
-	for (var prop in options) {
-		if (options.hasOwnProperty(prop)) {
-			this.options[prop] = options[prop];
-		}
-	}
+  // Override the default options
+  for (var prop in options) {
+    if (options.hasOwnProperty(prop)) {
+      this.options[prop] = options[prop];
+    }
+  }
 
-	this._client = pkgcloud.storage.createClient({
-		provider : 'rackspace',
-		username : this.options.user,
-		apiKey : this.options.key,
-		region : this.options.region,
-		useInternal : this.options.useSNET
-	});
+  this._client = pkgcloud.storage.createClient({
+    provider: "rackspace",
+    username: this.options.user,
+    apiKey: this.options.key,
+    region: this.options.region,
+    useInternal: this.options.useSNET
+  });
 
-	this.config = null;
-	this.aContainers = null;
+  this.config = null;
+  this.aContainers = null;
 };
 
 Rackit.defaultOptions = {
-	user : '',
-	key : '',
-	prefix : 'dev',
-	authRegion : 'US',
-	region : '',
-	authURIs : {
-		'UK' : 'https://lon.identity.api.rackspacecloud.com/v2.0',
-		'US' : 'https://identity.api.rackspacecloud.com/v2.0'
-	},
-	tempURLKey : null,
-	useSNET : false,
-	useCDN : true,
-	useSSL : true,
-	verbose : false,
-	logger : console.log,
-	listLimit : 10000
+  user: "",
+  key: "",
+  prefix: "dev",
+  authRegion: "US",
+  region: "",
+  authURIs: {
+    UK: "https://lon.identity.api.rackspacecloud.com/v2.0",
+    US: "https://identity.api.rackspacecloud.com/v2.0"
+  },
+  tempURLKey: null,
+  useSNET: false,
+  useCDN: true,
+  useSSL: true,
+  verbose: false,
+  logger: console.log,
+  listLimit: 10000
 };
 
 /**
  * Initializes the cloud connection and gets the local cache of containers
  */
-Rackit.prototype.init = function (cb) {
-	var o1 = this;
+Rackit.prototype.init = function(cb) {
+  var o1 = this;
 
-	if (!o1.options.user || !o1.options.key) {
-		return cb(new Error('No credentials'));
-	}
+  if (!o1.options.user || !o1.options.key) {
+    return cb(new Error("No credentials"));
+  }
 
-	// Authenticate with Cloud Files and get an initial container cache
-	async.series({
-		// First authenticate with Cloud Files
-		auth : function (cb) {
-			o1._client.auth(function (err) {
-				if (err && !(err instanceof Error)) {
-					err = new Error(err.message || err);
-				}
+  // Authenticate with Cloud Files and get an initial container cache
+  async.series(
+    {
+      // First authenticate with Cloud Files
+      auth: function(cb) {
+        o1._client.auth(function(err) {
+          if (err && !(err instanceof Error)) {
+            err = new Error(err.message || err);
+          }
 
-				if (!err) {
-					o1.config = {
-						storage : o1._client._serviceUrl
-					};
-				}
-				cb(err);
-			});
-		},
-		two : function (cb) {
-			async.parallel({
-				// Generate the cache of container objects
-				one : function (cb) {
-					o1._getContainers(cb);
-				},
-				// Set Account Metadata Key for public access
-				two : function (cb) {
-					if (o1.options.tempURLKey) {
-						o1._log('Setting temporary URL key for account...');
-						o1._client.setTemporaryUrlKey(o1.options.tempURLKey, cb);
-					} else {
-						cb();
-					}
-				}
-			}, cb);
-		}
-	}, function (err, results) {
-		// Avoid passing the results parameter on
-		return cb(err);
-	});
+          if (!err) {
+            o1.config = {
+              storage: o1._client._serviceUrl
+            };
+          }
+          cb(err);
+        });
+      },
+      two: function(cb) {
+        async.parallel(
+          {
+            // Generate the cache of container objects
+            one: function(cb) {
+              o1._getContainers(cb);
+            },
+            // Set Account Metadata Key for public access
+            two: function(cb) {
+              if (o1.options.tempURLKey) {
+                o1._log("Setting temporary URL key for account...");
+                o1._client.setTemporaryUrlKey(o1.options.tempURLKey, cb);
+              } else {
+                cb();
+              }
+            }
+          },
+          cb
+        );
+      }
+    },
+    function(err, results) {
+      // Avoid passing the results parameter on
+      return cb(err);
+    }
+  );
 };
 
-Rackit.prototype._log = function () {
-	arguments[0] = 'rackit: ' + arguments[0];
-	if (this.options.verbose) {
-		this.options.logger.apply(null, arguments);
-	}
+Rackit.prototype._log = function() {
+  arguments[0] = "rackit: " + arguments[0];
+  if (this.options.verbose) {
+    this.options.logger.apply(null, arguments);
+  }
+};
+
+/**
+* Get temporary upload PUT URI for client direct upload
+*  @param {string} sCloudPath - The relative path to the cloud file <container>/<file>
+*  @param {number} ttl - The number of seconds the link should remain active
+*/
+Rackit.prototype.tempPutUri = function(sCloudPath, ttl) {
+  let o1 = this;
+  if (!o1.options.tempURLKey) {
+    o1._log("You must specify a temp URL key to generate temp URL's");
+    return null;
+  }
+
+  o1._getContainer(function(err, container) {
+    var method = "PUT";
+    var expires = Math.floor(Date.now() / 1000) + ttl;
+    var storage = o1.config.storage.replace("https://snet-", "https://");
+    var storageParts = url.parse(storage);
+    var path = storageParts.pathname + "/" + container.name + "/" + sCloudPath;
+
+    var body = method + "\n" + expires + "\n" + path;
+    o1._log(body);
+    o1._log(o1.options.tempURLKey);
+
+    var hash = crypto
+      .createHmac("sha1", o1.options.tempURLKey)
+      .update(body)
+      .digest("hex");
+
+    var uri = storageParts.protocol +
+      "//" +
+      storageParts.host +
+      path +
+      "?temp_url_sig=" +
+      hash +
+      "&temp_url_expires=" +
+      expires;
+
+		return uri;
+  });
 };
 
 /**
  * Gets info about containers, including CDN containers
  * @param {function(err)} cb
  */
-Rackit.prototype._getContainers = function (cb) {
-	var o1 = this;
+Rackit.prototype._getContainers = function(cb) {
+  var o1 = this;
 
-	o1._log('getting containers...');
+  o1._log("getting containers...");
 
-	// Get container info
-	var aContainers = [];
+  // Get container info
+  var aContainers = [];
 
-	var next = 0;
-	async.whilst(function () {
-		return next >= 0;
-	}, function (cb) {
-		o1._log('Probing for container ' + o1.options.prefix + next);
-		o1._client.getContainer(o1.options.prefix + next, function (err, container) {
-			if ( err && err.statusCode && err.statusCode >= 500 ) {
-				return cb(err);
-			} else if ( err ) {
-				next = -1;
-				return cb();
-			}
+  var next = 0;
+  async.whilst(
+    function() {
+      return next >= 0;
+    },
+    function(cb) {
+      o1._log("Probing for container " + o1.options.prefix + next);
+      o1._client.getContainer(o1.options.prefix + next, function(
+        err,
+        container
+      ) {
+        if (err && err.statusCode && err.statusCode >= 500) {
+          return cb(err);
+        } else if (err) {
+          next = -1;
+          return cb();
+        }
 
-			aContainers.push(container);
-			next++;
-			cb();
-		});
-	}, function (err) {
-		if ( !err ) {
-			o1._log('Got ' + aContainers.length + ' containers');
-			o1.aContainers = aContainers;
-		}
-		cb(err);
-	});
+        aContainers.push(container);
+        next++;
+        cb();
+      });
+    },
+    function(err) {
+      if (!err) {
+        o1._log("Got " + aContainers.length + " containers");
+        o1.aContainers = aContainers;
+      }
+      cb(err);
+    }
+  );
 };
 
 /**
  * Adds a new prefixed container. Can optionally CDN enable the container.
  * @param {function(err)} cb
  */
-Rackit.prototype._createContainer = function (cb) {
-	var o1 = this;
-	var aContainers = o1.aContainers;
-	var container;
+Rackit.prototype._createContainer = function(cb) {
+  var o1 = this;
+  var aContainers = o1.aContainers;
+  var container;
 
-	var topContainer = _.last(aContainers);
+  var topContainer = _.last(aContainers);
 
-	var sName;
-	if (!topContainer)
-		sName = o1.options.prefix + '0';
-	else {
-		sName = o1.options.prefix + (parseInt(topContainer.name.match(/\d+$/)[0]) + 1);
-	}
+  var sName;
+  if (!topContainer)
+    sName = o1.options.prefix + "0";
+  else {
+    sName = o1.options.prefix +
+      (parseInt(topContainer.name.match(/\d+$/)[0]) + 1);
+  }
 
-	o1._log('adding container \'' + sName + '\'...');
+  o1._log("adding container '" + sName + "'...");
 
-	async.series([
-		// Create the container
-		function (cb) {
-			o1._client.createContainer(sName, function (err, _container) {
-				if (err)
-					return cb(err);
+  async.series(
+    [
+      // Create the container
+      function(cb) {
+        o1._client.createContainer(sName, function(err, _container) {
+          if (err) return cb(err);
 
-				// check that a parallel operation didn't just add the same container
-				container = _.find(o1.aContainers, { name : sName });
+          // check that a parallel operation didn't just add the same container
+          container = _.find(o1.aContainers, { name: sName });
 
-				if (!container) {
-					o1.aContainers.push(_container);
-					container = _container;
-				}
+          if (!container) {
+            o1.aContainers.push(_container);
+            container = _container;
+          }
 
-				cb();
-			});
-		},
-		// CDN enable the container, if necessary
-		function (cb) {
-			if (!o1.options.useCDN)
-				return cb();
+          cb();
+        });
+      },
+      // CDN enable the container, if necessary
+      function(cb) {
+        if (!o1.options.useCDN) return cb();
 
-			o1._log('CDN enabling the container');
+        o1._log("CDN enabling the container");
 
-			container.enableCdn(function (err, _container) {
-				if (err)
-					return cb(err);
+        container.enableCdn(function(err, _container) {
+          if (err) return cb(err);
 
-				// check that a parallel operation didn't just CDN enable the same container
-				var index = _.findIndex(o1.aContainers, { name : sName });
+          // check that a parallel operation didn't just CDN enable the same container
+          var index = _.findIndex(o1.aContainers, { name: sName });
 
-				container = o1.aContainers[index] = _container;
+          container = o1.aContainers[index] = _container;
 
-				cb();
-			});
-		}],
-		function (err) {
-			cb(err, container);
-		});
+          cb();
+        });
+      }
+    ],
+    function(err) {
+      cb(err, container);
+    }
+  );
 };
 
 /**
@@ -222,29 +277,29 @@ Rackit.prototype._createContainer = function (cb) {
  * created. There may be other containers, which will be ignored.
  * @param {function(Error, string)} cb - callback(Error, sContainer)
  */
-Rackit.prototype._getContainer = function (cb) {
-	var o1 = this;
-	var aContainers = o1.aContainers;
+Rackit.prototype._getContainer = function(cb) {
+  var o1 = this;
+  var aContainers = o1.aContainers;
 
-	// Check that we found a prefixed container
-	if (!aContainers.length) {
-		// If no existing containers, create one!
-		o1._createContainer(cb);
-		return;
-	}
+  // Check that we found a prefixed container
+  if (!aContainers.length) {
+    // If no existing containers, create one!
+    o1._createContainer(cb);
+    return;
+  }
 
-	// We have containers. Get the most recent one.
-	var container = _.last(aContainers);
+  // We have containers. Get the most recent one.
+  var container = _.last(aContainers);
 
-	// Check if the container is full
-	if (container.count >= 50000) {
-		// The container is full, create the next one
-		o1._createContainer(cb);
-		return;
-	}
+  // Check if the container is full
+  if (container.count >= 50000) {
+    // The container is full, create the next one
+    o1._createContainer(cb);
+    return;
+  }
 
-	// The container we found is fine.. return it.
-	cb(null, container);
+  // The container we found is fine.. return it.
+  cb(null, container);
 };
 
 /**
@@ -253,142 +308,146 @@ Rackit.prototype._getContainer = function (cb) {
  * @param {{type: string, filename: string, meta: Object, headers: Object.<string, string>}|function(?Error, string=)} options - Additonal options
  * @param {function(?Error, string=)} cb - Callback, returns error or the cloud path
  */
-Rackit.prototype.add = function (source, options, cb) {
-	var o1 = this;
+Rackit.prototype.add = function(source, options, cb) {
+  var o1 = this;
 
-	// Ensure things have been initialized
-	if (!o1.aContainers)
-		throw new Error('Attempting to use container information without initializing Rackit. Please call rackit.init() first.');
+  // Ensure things have been initialized
+  if (!o1.aContainers)
+    throw new Error(
+      "Attempting to use container information without initializing Rackit. Please call rackit.init() first."
+    );
 
-	// Normalize options
-	if (typeof options === 'function') {
-		cb = options;
-		options = null;
-	}
+  // Normalize options
+  if (typeof options === "function") {
+    cb = options;
+    options = null;
+  }
 
-	// Sanity check the source
-	if (!source) {
-		o1._log('no file source specified');
-		return cb(new Error('No file source'));
-	}
+  // Sanity check the source
+  if (!source) {
+    o1._log("no file source specified");
+    return cb(new Error("No file source"));
+  }
 
-	var fromFile = typeof source === 'string';
+  var fromFile = typeof source === "string";
 
-	// If the source is a stream, ensure it is readable
-	if (!fromFile && source.readable !== true) {
-		o1._log('not a valid stream');
-		return cb(new Error('Not a valid stream'));
-	}
+  // If the source is a stream, ensure it is readable
+  if (!fromFile && source.readable !== true) {
+    o1._log("not a valid stream");
+    return cb(new Error("Not a valid stream"));
+  }
 
-	// Set default options
-	options = options || {};
-	options.meta = options.meta || {};
+  // Set default options
+  options = options || {};
+  options.meta = options.meta || {};
 
-	if (fromFile) {
-		o1._log('adding file', source);
-	} else {
-		o1._log('adding file', 'from stream');
-		// Pause the source stream so we can catch the data in the callback below
-		// Note: pause is advisory, so it's possible the stream will emit data before we resume it.
-		// This should only occur for http request streams (not file streams), and can be fixed
-		// by wrapping the stream in a buffered stream. Streams will internally buffer in node v0.9
-		source.pause();
-	}
+  if (fromFile) {
+    o1._log("adding file", source);
+  } else {
+    o1._log("adding file", "from stream");
+    // Pause the source stream so we can catch the data in the callback below
+    // Note: pause is advisory, so it's possible the stream will emit data before we resume it.
+    // This should only occur for http request streams (not file streams), and can be fixed
+    // by wrapping the stream in a buffered stream. Streams will internally buffer in node v0.9
+    source.pause();
+  }
 
-	// Determine the type
-	var type = options.type;
+  // Determine the type
+  var type = options.type;
 
-	if (!type) {
-		if (fromFile)
-			type = mime.lookup(source);
-		else {
-			// The source is a stream, so it might already be a reqeust with a content-type header.
-			// In this case, the content-type will be forwarded automatically
-			type = source.headers && source.headers['content-type'];
-			if (!type) {
-				return cb(new Error('Unable to determine content-type. You must specify the type for file streams.'));
-			}
-		}
-	}
+  if (!type) {
+    if (fromFile)
+      type = mime.lookup(source);
+    else {
+      // The source is a stream, so it might already be a reqeust with a content-type header.
+      // In this case, the content-type will be forwarded automatically
+      type = source.headers && source.headers["content-type"];
+      if (!type) {
+        return cb(new Error(
+          "Unable to determine content-type. You must specify the type for file streams."
+        ));
+      }
+    }
+  }
 
-	async.parallel({
-			// If the source is a file, make sure it exists
-			stats : function (cb) {
-				if (fromFile)
-					fs.stat(source, cb);
-				else
-					cb();
-			},
-			// Get the file container
-			container : function (cb) {
-				o1._getContainer(cb);
-			}
-		},
-		// Final function of parallel.. create the request to add the file
-		function (err, results) {
-			if (err) {
-				return cb(err);
-			}
+  async.parallel(
+    {
+      // If the source is a file, make sure it exists
+      stats: function(cb) {
+        if (fromFile) fs.stat(source, cb);
+        else cb();
+      },
+      // Get the file container
+      container: function(cb) {
+        o1._getContainer(cb);
+      }
+    },
+    // Final function of parallel.. create the request to add the file
+    function(err, results) {
+      if (err) {
+        return cb(err);
+      }
 
-			// Generate file id
-			var id = options.filename || utils.uid(24);
+      // Generate file id
+      var id = options.filename || utils.uid(24);
 
-			//
-			// Generate the headers to be send to Rackspace
-			//
+      //
+      // Generate the headers to be send to Rackspace
+      //
 
-			var headers = {};
-			// set the content-length of transfer-encoding as appropriate
-			if (fromFile) {
-				headers['content-length'] = results.stats.size;
-			} else {
-				if (source.headers && source.headers['content-length'])
-					headers['content-length'] = source.headers['content-length'];
-				else
-					headers['transfer-encoding'] = 'chunked';
-			}
+      var headers = {};
+      // set the content-length of transfer-encoding as appropriate
+      if (fromFile) {
+        headers["content-length"] = results.stats.size;
+      } else {
+        if (source.headers && source.headers["content-length"])
+          headers["content-length"] = source.headers["content-length"];
+        else
+          headers["transfer-encoding"] = "chunked";
+      }
 
-			// Add any additonal headers
-			var sKey;
-			for (sKey in options.headers) {
-				if (options.headers.hasOwnProperty(sKey)) {
-					headers[sKey] = options.headers[sKey];
-				}
-			}
+      // Add any additonal headers
+      var sKey;
+      for (sKey in options.headers) {
+        if (options.headers.hasOwnProperty(sKey)) {
+          headers[sKey] = options.headers[sKey];
+        }
+      }
 
-			//
-			// Generate the cloud request options
-			//
-			var _options = {
-				container : results.container.name,
-				remote : id,
-				headers : headers,
-				metadata : options.meta,
-				contentType : type
-			};
+      //
+      // Generate the cloud request options
+      //
+      var _options = {
+        container: results.container.name,
+        remote: id,
+        headers: headers,
+        metadata: options.meta,
+        contentType: type
+      };
 
-			var readStream;
-			if (fromFile)
-				readStream = fs.createReadStream(source);
-			else {
-				readStream = source;
-				source.resume();
-				if (source.headers) {
-					// We want to remove any headers from the source stream so they don't clobber our own headers.
-					delete source.headers;
-				}
-			}
+      var readStream;
+      if (fromFile)
+        readStream = fs.createReadStream(source);
+      else {
+        readStream = source;
+        source.resume();
+        if (source.headers) {
+          // We want to remove any headers from the source stream so they don't clobber our own headers.
+          delete source.headers;
+        }
+      }
 
-			var writeStream = o1._client.upload(_options);
+      var writeStream = o1._client.upload(_options);
 
-			writeStream.on('error', cb);
-			writeStream.on('success', function (file) {
-				results.container.count++;
-				cb(null, results.container.name + '/' + id);
-			});
+      writeStream.on("error", cb);
+      writeStream.on("success", function(file) {
+        results.container.count++;
+        cb(null, results.container.name + "/" + id);
+      });
 
-			readStream.pipe(writeStream);
-		});
+      readStream.pipe(writeStream);
+    }
+  );
 };
 
 /**
@@ -397,97 +456,99 @@ Rackit.prototype.add = function (source, options, cb) {
  * @param {Object} options an optional hash specifing some additional options. Currently 'extended' is supported.
  * @param {function(Array)} cb(err, aCloudpaths)
  */
-Rackit.prototype.list = function (options, cb) {
-	// Get from the 0 container
-	var o1 = this;
-	var aObjects = [];
+Rackit.prototype.list = function(options, cb) {
+  // Get from the 0 container
+  var o1 = this;
+  var aObjects = [];
 
-	// Ensure things have been initialized
-	if (!o1.aContainers)
-		throw new Error('Attempting to use container information without initializing Rackit. Please call rackit.init() first.');
+  // Ensure things have been initialized
+  if (!o1.aContainers)
+    throw new Error(
+      "Attempting to use container information without initializing Rackit. Please call rackit.init() first."
+    );
 
-	// Normalize the parameters
-	if (typeof options === 'function') {
-		cb = options;
-		options = {};
-	}
+  // Normalize the parameters
+  if (typeof options === "function") {
+    cb = options;
+    options = {};
+  }
 
-	// List the objects for each container in parallel
-	var aContainers = o1.aContainers;
-	async.forEach(
-		aContainers,
-		function (container, cb) {
-			o1._listContainer(container, function (err, aSomeObjects) {
-				if (err)
-					return cb(err);
+  // List the objects for each container in parallel
+  var aContainers = o1.aContainers;
+  async.forEach(
+    aContainers,
+    function(container, cb) {
+      o1._listContainer(container, function(err, aSomeObjects) {
+        if (err) return cb(err);
 
-				aObjects = aObjects.concat(aSomeObjects);
-				cb();
-			});
-		},
-		// Final function of forEach
-		function (err) {
-			var i;
+        aObjects = aObjects.concat(aSomeObjects);
+        cb();
+      });
+    },
+    // Final function of forEach
+    function(err) {
+      var i;
 
-			// If the extended option is off, just return cloudpaths
-			if (!options.extended) {
-				i = aObjects.length;
-				while (i--) {
-					aObjects[i] = aObjects[i].cloudpath;
-				}
-			}
+      // If the extended option is off, just return cloudpaths
+      if (!options.extended) {
+        i = aObjects.length;
+        while (i--) {
+          aObjects[i] = aObjects[i].cloudpath;
+        }
+      }
 
-			cb(err, err ? undefined : aObjects);
-		}
-	);
+      cb(err, err ? undefined : aObjects);
+    }
+  );
 };
 
 // Returns an array of all the objects in a container
-Rackit.prototype._listContainer = function (container, cb) {
-	var o1 = this;
-	var objects = [];
+Rackit.prototype._listContainer = function(container, cb) {
+  var o1 = this;
+  var objects = [];
 
-	// A callback to receive some of the containers objects
-	function receiveSomeResults(err, someObjects) {
-		if (err) {
-			return cb(err);
-		}
+  // A callback to receive some of the containers objects
+  function receiveSomeResults(err, someObjects) {
+    if (err) {
+      return cb(err);
+    }
 
-		// Add the results to the master array
-		objects = objects.concat(someObjects);
+    // Add the results to the master array
+    objects = objects.concat(someObjects);
 
-		// If the latest results contained the list limit, request more
-		if (someObjects.length >= o1.options.listLimit) {
-			o1._listContainerPart(container, someObjects.pop().name, receiveSomeResults);
-			return;
-		}
+    // If the latest results contained the list limit, request more
+    if (someObjects.length >= o1.options.listLimit) {
+      o1._listContainerPart(
+        container,
+        someObjects.pop().name,
+        receiveSomeResults
+      );
+      return;
+    }
 
-		// Return the object array
-		cb(null, objects);
-	}
+    // Return the object array
+    cb(null, objects);
+  }
 
-	// Set of the listing for this container
-	o1._listContainerPart(container, null, receiveSomeResults);
+  // Set of the listing for this container
+  o1._listContainerPart(container, null, receiveSomeResults);
 };
 
 // Returns some of the objects in a container
-Rackit.prototype._listContainerPart = function (container, marker, cb) {
-	var o1 = this;
-	var options = { limit : o1.options.listLimit };
+Rackit.prototype._listContainerPart = function(container, marker, cb) {
+  var o1 = this;
+  var options = { limit: o1.options.listLimit };
 
-	if (marker)
-		options.marker = marker;
+  if (marker) options.marker = marker;
 
-	o1._client.getFiles(container, options, function (err, files) {
-		if (err)
-			return cb(err);
+  o1._client.getFiles(container, options, function(err, files) {
+    if (err) return cb(err);
 
-		var i = files.length;
-		while (i--)
-			files[i].cloudpath = container.name + '/' + files[i].name;
+    var i = files.length;
+    while (i--) files[i].cloudpath = container.name + "/" + files[i].name;
 
-		cb(null, files);
-	});
+    cb(null, files);
+  });
 };
 
 /**
@@ -497,41 +558,41 @@ Rackit.prototype._listContainerPart = function (container, marker, cb) {
  * @param {function=} cb(err)
  * @return the request stream
  */
-Rackit.prototype.get = function (sCloudPath, localPath, cb) {
-	var o1 = this;
-	o1._log('getting file', sCloudPath);
+Rackit.prototype.get = function(sCloudPath, localPath, cb) {
+  var o1 = this;
+  o1._log("getting file", sCloudPath);
 
-	// Normalize parameters
-	if (typeof localPath === 'function') {
-		cb = localPath;
-		localPath = null;
-	}
+  // Normalize parameters
+  if (typeof localPath === "function") {
+    cb = localPath;
+    localPath = null;
+  }
 
-	var aPieces = sCloudPath.match(/^\/{0,1}([^/]+)\/(.+)$/);
-	var sContainer = aPieces[1];
-	var sName = aPieces[2];
+  var aPieces = sCloudPath.match(/^\/{0,1}([^/]+)\/(.+)$/);
+  var sContainer = aPieces[1];
+  var sName = aPieces[2];
 
-	var options = {
-		container : sContainer,
-		remote : sName
-	};
+  var options = {
+    container: sContainer,
+    remote: sName
+  };
 
-	var stream = o1._client.download(options);
+  var stream = o1._client.download(options);
 
-	if (localPath) {
-		cb = cb || function () {};
-		stream.on('error', cb);
+  if (localPath) {
+    cb = cb || function() {};
+    stream.on("error", cb);
 
-		var w = fs.createWriteStream(localPath);
-		w.on('error', cb);
-		w.on('finish', function () {
-			cb();
-		});
+    var w = fs.createWriteStream(localPath);
+    w.on("error", cb);
+    w.on("finish", function() {
+      cb();
+    });
 
-		stream.pipe(w);
-	}
+    stream.pipe(w);
+  }
 
-	return stream;
+  return stream;
 };
 
 /**
@@ -539,23 +600,22 @@ Rackit.prototype.get = function (sCloudPath, localPath, cb) {
  * @param {string} sCloudPath - The relative path to the cloud file <container>/<file>
  * @param {function(err)} cb
  */
-Rackit.prototype.remove = function (sCloudPath, cb) {
-	var o1 = this;
+Rackit.prototype.remove = function(sCloudPath, cb) {
+  var o1 = this;
 
-	var aPieces = sCloudPath.match(/^\/{0,1}([^/]+)\/(.+)$/);
-	var sContainer = aPieces[1];
-	var sName = aPieces[2];
+  var aPieces = sCloudPath.match(/^\/{0,1}([^/]+)\/(.+)$/);
+  var sContainer = aPieces[1];
+  var sName = aPieces[2];
 
-	o1._client.removeFile(sContainer, sName, function (err) {
-		if (err)
-			return cb(err);
+  o1._client.removeFile(sContainer, sName, function(err) {
+    if (err) return cb(err);
 
-		// decrement the internal container size
-		var container = _.find(o1.aContainers, { name : sContainer });
-		container.count--;
+    // decrement the internal container size
+    var container = _.find(o1.aContainers, { name: sContainer });
+    container.count--;
 
-		cb();
-	});
+    cb();
+  });
 };
 
 /**
@@ -564,23 +624,22 @@ Rackit.prototype.remove = function (sCloudPath, cb) {
  * @param {Object} meta
  * @param {function(Error)} cb
  */
-Rackit.prototype.setMeta = function (sCloudPath, meta, cb) {
-	var o1 = this;
+Rackit.prototype.setMeta = function(sCloudPath, meta, cb) {
+  var o1 = this;
 
-	var aPieces = sCloudPath.match(/^\/{0,1}([^/]+)\/(.+)$/);
-	var sContainer = aPieces[1];
-	var sName = aPieces[2];
+  var aPieces = sCloudPath.match(/^\/{0,1}([^/]+)\/(.+)$/);
+  var sContainer = aPieces[1];
+  var sName = aPieces[2];
 
-	// updateFileMetadata() requires a File instance, so make a dummy one
-	var file = new File(o1._client, { name : sName });
-	file.metadata = meta;
+  // updateFileMetadata() requires a File instance, so make a dummy one
+  var file = new File(o1._client, { name: sName });
+  file.metadata = meta;
 
-	o1._client.updateFileMetadata(sContainer, file, function (err) {
-		if (err)
-			return cb(err);
+  o1._client.updateFileMetadata(sContainer, file, function(err) {
+    if (err) return cb(err);
 
-		cb();
-	});
+    cb();
+  });
 };
 
 /*
@@ -591,19 +650,18 @@ Rackit.prototype.setMeta = function (sCloudPath, meta, cb) {
  * the object's information, including timestamp, ETag and content type.
  * The error will be present if the specified file does not exist.
  */
-Rackit.prototype.getMeta = function (sCloudPath, cb) {
-	var o1 = this;
+Rackit.prototype.getMeta = function(sCloudPath, cb) {
+  var o1 = this;
 
-	var aPieces = sCloudPath.match(/^\/{0,1}([^/]+)\/(.+)$/);
-	var sContainer = aPieces[1];
-	var sName = aPieces[2];
+  var aPieces = sCloudPath.match(/^\/{0,1}([^/]+)\/(.+)$/);
+  var sContainer = aPieces[1];
+  var sName = aPieces[2];
 
-	o1._client.getFile(sContainer, sName, function (err, file) {
-		if (err)
-			return cb(err);
+  o1._client.getFile(sContainer, sName, function(err, file) {
+    if (err) return cb(err);
 
-		cb(null, file.metadata);
-	});
+    cb(null, file.metadata);
+  });
 };
 
 /**
@@ -612,10 +670,10 @@ Rackit.prototype.getMeta = function (sCloudPath, cb) {
  * @param {number} ttl - The number of seconds the link should remain active (optional)
  * @return {string} The complete CDN URI to the file, or null if container not found
  */
-Rackit.prototype.getURI = function (sCloudPath, ttl) {
-	var o1 = this;
-	var uri = ttl ? o1._getTempURI(sCloudPath, ttl) : o1._getCDNURI(sCloudPath);
-	return uri;
+Rackit.prototype.getURI = function(sCloudPath, ttl) {
+  var o1 = this;
+  var uri = ttl ? o1._getTempURI(sCloudPath, ttl) : o1._getCDNURI(sCloudPath);
+  return uri;
 };
 
 /**
@@ -623,20 +681,29 @@ Rackit.prototype.getURI = function (sCloudPath, ttl) {
  * @param {string} sCloudPath - The relative path to the cloud file <container>/<file>
  * @return {string} The complete CDN URI to the file, or null if container not found
  */
-Rackit.prototype._getCDNURI = function (sCloudPath) {
-	var o1 = this;
-	var aPieces = sCloudPath.match(/^\/{0,1}([^/]+)\/(.+)$/);
-	var sContainer = aPieces[1];
-	var localPath = aPieces[2];
+Rackit.prototype._getCDNURI = function(sCloudPath) {
+  var o1 = this;
+  var aPieces = sCloudPath.match(/^\/{0,1}([^/]+)\/(.+)$/);
+  var sContainer = aPieces[1];
+  var localPath = aPieces[2];
 
-	var container = _.find(o1.aContainers, { name : sContainer, cdnEnabled : true });
-	if (!container) {
-		o1._log('The container ' + sContainer + ' is not CDN enabled. Unable to get CDN URI');
-		return null;
-	}
+  var container = _.find(o1.aContainers, {
+    name: sContainer,
+    cdnEnabled: true
+  });
+  if (!container) {
+    o1._log(
+      "The container " +
+        sContainer +
+        " is not CDN enabled. Unable to get CDN URI"
+    );
+    return null;
+  }
 
-	var uri = container[o1.options.useSSL ? 'cdnSslUri' : 'cdnUri'] + '/' + localPath;
-	return uri;
+  var uri = container[o1.options.useSSL ? "cdnSslUri" : "cdnUri"] +
+    "/" +
+    localPath;
+  return uri;
 };
 
 /**
@@ -645,31 +712,41 @@ Rackit.prototype._getCDNURI = function (sCloudPath) {
  * @param {number} ttl - The number of seconds the link should remain active
  * @return {string} The complete CDN URI to the file, or null if container not found
  */
-Rackit.prototype._getTempURI = function (sCloudPath, ttl) {
-	var o1 = this;
+Rackit.prototype._getTempURI = function(sCloudPath, ttl) {
+  var o1 = this;
 
-	// Ensure a temp url key has been set
-	if (!o1.options.tempURLKey) {
-		o1._log('You must specify a temp URL key to generate temp URIs');
-		return null;
-	}
+  // Ensure a temp url key has been set
+  if (!o1.options.tempURLKey) {
+    o1._log("You must specify a temp URL key to generate temp URIs");
+    return null;
+  }
 
-	// If ttl is given, generate a temp URI
-	var method = 'GET';
-	var expires = Math.floor(Date.now() / 1000) + ttl;
+  // If ttl is given, generate a temp URI
+  var method = "GET";
+  var expires = Math.floor(Date.now() / 1000) + ttl;
 
-	// Remove snet- from the url (if its there), since this will generally be a public url
-	var storage = o1.config.storage.replace('https://snet-', 'https://');
-	var storageParts = url.parse(storage);
-	var path = storageParts.pathname + '/' + sCloudPath;
+  // Remove snet- from the url (if its there), since this will generally be a public url
+  var storage = o1.config.storage.replace("https://snet-", "https://");
+  var storageParts = url.parse(storage);
+  var path = storageParts.pathname + "/" + sCloudPath;
 
-	var body = method + '\n' + expires + '\n' + path;
+  var body = method + "\n" + expires + "\n" + path;
 
-	o1._log(body);
-	o1._log(o1.options.tempURLKey);
-	var hash = crypto.createHmac('sha1', o1.options.tempURLKey).update(body).digest('hex');
-	var uri = storageParts.protocol + '//' + storageParts.host + path + '?temp_url_sig=' + hash + '&temp_url_expires=' + expires;
-	return uri;
+  o1._log(body);
+  o1._log(o1.options.tempURLKey);
+  var hash = crypto
+    .createHmac("sha1", o1.options.tempURLKey)
+    .update(body)
+    .digest("hex");
+  var uri = storageParts.protocol +
+    "//" +
+    storageParts.host +
+    path +
+    "?temp_url_sig=" +
+    hash +
+    "&temp_url_expires=" +
+    expires;
+  return uri;
 };
 
 /**
@@ -678,14 +755,16 @@ Rackit.prototype._getTempURI = function (sCloudPath, ttl) {
  * @param {string} uri - A CDN or temporary URI representing a particular file
  * @return {string} The Cloudpath representing the file
  */
-Rackit.prototype.getCloudpath = function (uri) {
-	var o1 = this;
+Rackit.prototype.getCloudpath = function(uri) {
+  var o1 = this;
 
-	// Check if the provided URI is a temp URI
-	var storage = o1.config.storage.replace('https://snet-', 'https://');
-	var cloudpath = uri.substring(0, storage.length) === storage ? o1._cloudpathFromTempURI(uri) : o1._cloudpathFromCDNURI(uri);
+  // Check if the provided URI is a temp URI
+  var storage = o1.config.storage.replace("https://snet-", "https://");
+  var cloudpath = uri.substring(0, storage.length) === storage
+    ? o1._cloudpathFromTempURI(uri)
+    : o1._cloudpathFromCDNURI(uri);
 
-	return cloudpath;
+  return cloudpath;
 };
 
 /**
@@ -694,31 +773,35 @@ Rackit.prototype.getCloudpath = function (uri) {
  * @param {string} uri - A CDN URI representing a particular file
  * @return {string} The Cloudpath representing the file
  */
-Rackit.prototype._cloudpathFromCDNURI = function (uri) {
-	var o1 = this;
-	var parts = url.parse(uri);
-	// Determine which container property to search for.. ssl uri or regular uri
-	var uriProperty = parts.protocol === 'https:' ? 'cdnSslUri' : 'cdnUri';
+Rackit.prototype._cloudpathFromCDNURI = function(uri) {
+  var o1 = this;
+  var parts = url.parse(uri);
+  // Determine which container property to search for.. ssl uri or regular uri
+  var uriProperty = parts.protocol === "https:" ? "cdnSslUri" : "cdnUri";
 
-	// Get the base part of the given uri. This should equal the containers cdn_ssl_uri or cdn_uri
-	var base = parts.protocol + '//' + parts.host;
+  // Get the base part of the given uri. This should equal the containers cdn_ssl_uri or cdn_uri
+  var base = parts.protocol + "//" + parts.host;
 
-	// Find the CDN container that has a matching base URI
-	var search = {
-		cdnEnabled : true
-	};
-	search[uriProperty] = base;
-	var container = _.find(o1.aContainers, search);
+  // Find the CDN container that has a matching base URI
+  var search = {
+    cdnEnabled: true
+  };
+  search[uriProperty] = base;
+  var container = _.find(o1.aContainers, search);
 
-	// If we couldn't find a container, output a message
-	if (!container) {
-		o1._log('The container with URI ' + base + ' could not be found. Unable to get Cloudpath');
-		return null;
-	}
+  // If we couldn't find a container, output a message
+  if (!container) {
+    o1._log(
+      "The container with URI " +
+        base +
+        " could not be found. Unable to get Cloudpath"
+    );
+    return null;
+  }
 
-	// Get the cloudpath
-	var cloudpath = container.name + parts.pathname;
-	return cloudpath;
+  // Get the cloudpath
+  var cloudpath = container.name + parts.pathname;
+  return cloudpath;
 };
 
 /**
@@ -727,11 +810,13 @@ Rackit.prototype._cloudpathFromCDNURI = function (uri) {
  * @param {string} uri - A temporary URI representing a particular file
  * @return {string} The Cloudpath representing the file
  */
-Rackit.prototype._cloudpathFromTempURI = function (uri) {
-	var parts = url.parse(uri).pathname.match(/^\/?(?:v1\/[^\/]+\/)?([^/]+)\/(.+)$/);
-	var file = parts[2];
-	var container = parts[1];
-	return container + '/' + file;
+Rackit.prototype._cloudpathFromTempURI = function(uri) {
+  var parts = url
+    .parse(uri)
+    .pathname.match(/^\/?(?:v1\/[^\/]+\/)?([^/]+)\/(.+)$/);
+  var file = parts[2];
+  var container = parts[1];
+  return container + "/" + file;
 };
 
 module.exports = Rackit;

--- a/lib/rackit.js
+++ b/lib/rackit.js
@@ -229,15 +229,23 @@ Rackit.prototype._createContainer = function(cb) {
 
   o1._log("adding container '" + sName + "'...");
 
+  var options = {
+    name: sName, 
+  }
+
+  if ( o1.options.containerMetadata ){
+    options.metadata = o1.options.containerMetadata;
+  }
+
   async.series(
     [
       // Create the container
       function(cb) {
-        o1._client.createContainer(sName, function(err, _container) {
+        o1._client.createContainer(options, function(err, _container) {
           if (err) return cb(err);
 
           // check that a parallel operation didn't just add the same container
-          container = _.find(o1.aContainers, { name: sName });
+          container = _.find(o1.aContainers, { name: options.name });
 
           if (!container) {
             o1.aContainers.push(_container);
@@ -257,7 +265,7 @@ Rackit.prototype._createContainer = function(cb) {
           if (err) return cb(err);
 
           // check that a parallel operation didn't just CDN enable the same container
-          var index = _.findIndex(o1.aContainers, { name: sName });
+          var index = _.findIndex(o1.aContainers, { name: options.name });
 
           container = o1.aContainers[index] = _container;
 


### PR DESCRIPTION
Currently when a container rolls over its file limit and a new container is created there is no way to automatically apply additional container level metadata. I've added the option `containerMetadata` to the Rackit options to allow a user to provide default metadata that's passed to `pkgcloud` on container creation. 

The `containerMetadata` field is optional, and rackit will still function as expected if its not provided. 

To use: 

``` javascript
var options = {
//...
containerMetadata: {
  "Access-Control-Expose-Headers": "etag location x-timestamp x-trans-id", // Expose additional headers in responses
  "Access-Control-Allow-Origin": "arbitrarydomain.com" // Set CORS headers
  "Some-Random-Header": "because we can" 
}
//...
}
```